### PR TITLE
Add rootProject.name to settings.gradle

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -9,3 +9,5 @@ pluginManagement {
         id("org.jetbrains.compose").version(extra["compose.version"] as String)
     }
 }
+
+rootProject.name = "compose-multiplatform-html-library-template"


### PR DESCRIPTION
Because this name is used in index.html. If users name their folder differentlyt, it won't run