### PR TITLE
Update Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,4 +5,4 @@
 This template uses the HTML Compose library.
 
 - `./gradlew jsBrowserRun` - run application in a browser
-- `./gradlew jsBrowserProductionWebpack` - produce the output in `build/distributions`
+- `./gradlew jsBrowserProductionWebpack` - produce the output in `build/dist`


### PR DESCRIPTION
The `distribution` folder was renamed to `dist` in kotlin 1.9.0